### PR TITLE
make specifying superuserPassword & secretKey more secure

### DIFF
--- a/charts/langflow-ide/Chart.yaml
+++ b/charts/langflow-ide/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: langflow-ide
 description: Helm chart for Langflow IDE
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: latest
 maintainers:
   - name: Langflow

--- a/charts/langflow-ide/templates/backend-statefulset.yaml
+++ b/charts/langflow-ide/templates/backend-statefulset.yaml
@@ -130,11 +130,11 @@ spec:
             - name: LANGFLOW_AUTO_LOGIN
               value: "{{ .Values.langflow.backend.autoLogin | default "False" }}"
             - name: LANGFLOW_SUPERUSER
-              value: "{{ .Values.langflow.backend.superuser | default "admin" }}"
+            {{- toYaml .Values.langflow.backend.superuser }}
             - name: LANGFLOW_SUPERUSER_PASSWORD
-              value: "{{ .Values.langflow.backend.superuserPassword | default (randAlphaNum 32) }}"
+            {{- toYaml .Values.langflow.backend.superuserPassword }}
             - name: LANGFLOW_SECRET_KEY
-              value: "{{ .Values.langflow.backend.secretKey | default (randAlphaNum 32) }}"
+            {{- toYaml .Values.langflow.backend.secretKey }}"
             - name: LANGFLOW_NEW_USER_IS_ACTIVE
               value: "{{ .Values.langflow.backend.newUserIsActive | default "False" }}"
             {{- end }}


### PR DESCRIPTION
currently, the superuser, superuserPassword & secretKey are directly pulled as values into the backend chart. This prevents us from using Kubernetes Secrets for these values and instead requires them to be hard coded in values.yaml. This change allows Kubernetes Secrets to be used similar to how externaldb envs are handled